### PR TITLE
Fix: Correct typo in getTotalKeywordStasus function name

### DIFF
--- a/src/Helpers/KeywordHelper.php
+++ b/src/Helpers/KeywordHelper.php
@@ -40,7 +40,7 @@ class KeywordHelper
         return strtotime($secondDate["last_update_date"]) - strtotime($firstDate["last_update_date"]);
     }
 
-    public function getTotalKeywordStasus($dateFromFormat)
+    public function getTotalKeywordStatus($dateFromFormat)
     {
         $databaseHelper = wprtContainer('DatabaseHelper');
         $rankController = wprtContainer('RankController');

--- a/src/Modules/Cron/ReportSenderCronController.php
+++ b/src/Modules/Cron/ReportSenderCronController.php
@@ -192,7 +192,7 @@ class ReportSenderCronController
 
         $dateFromFormat = $this->getReportFromFormat($frequency);
         $this->updateLatestData($dateFromFormat);
-        $keywords = $keywordHelper->getTotalKeywordStasus($dateFromFormat);
+        $keywords = $keywordHelper->getTotalKeywordStatus($dateFromFormat);
 
         if(count($keywords['allKeywords']) === 0){
             return;

--- a/templates/components/overview.php
+++ b/templates/components/overview.php
@@ -82,7 +82,7 @@ $keywordHelper = wprtContainer('KeywordHelper');
                         <?php esc_html_e('7 Days Average', 'easy-rank-tracker') ?>
                     </div>
                     <?php
-	                    $keywordStatus = $keywordHelper->getTotalKeywordStasus("-7 days");
+	                    $keywordStatus = $keywordHelper->getTotalKeywordStatus("-7 days");
 	                    $className = '';
 	                    $iconName = 'arrow-up.png';
 	                    if (count($keywordStatus['downKeywords']) > count($keywordStatus['upKeywords'])) {
@@ -142,7 +142,7 @@ $keywordHelper = wprtContainer('KeywordHelper');
                         <?php esc_html_e('30 Days Average', 'easy-rank-tracker') ?>
                     </div>
                     <?php
-                    $keywordStatus = $keywordHelper->getTotalKeywordStasus("-30 days");
+                    $keywordStatus = $keywordHelper->getTotalKeywordStatus("-30 days");
                     $className = '';
                     $iconName = 'arrow-up.png';
                     if (count($keywordStatus['downKeywords']) > count($keywordStatus['upKeywords'])) {


### PR DESCRIPTION
Renamed the typo "getTotalKeywordStasus" function name to "getTotalKeywordStatus " and updated all references accordingly.